### PR TITLE
Trying to build on OS X

### DIFF
--- a/src/bstrlib.c
+++ b/src/bstrlib.c
@@ -2756,6 +2756,7 @@ struct genBstrList g;
 #define START_VSNBUFF (256)
 #else
 
+#if 0
 #ifdef __GNUC__
 /* Something is making gcc complain about this prototype not being here, so 
    I've just gone ahead and put it in. */
@@ -2763,6 +2764,7 @@ extern int vsnprintf (char *buf, size_t count, const char *format, va_list arg);
 #endif
 
 #define exvsnprintf(r,b,n,f,a) {r = vsnprintf (b,n,f,a);}
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
This fixes and `expected parameter declarator` error for `vsnprintf` on mac osx.

However one error remains and I don't know how to fix it:

```
$ make dev
cc -g -Wall -Isrc -I/usr/local/Cellar/postgresql-9.5/9.5beta1/include -Wall -Wextra    -c -o src/main.o src/main.c
src/main.c:11:10: fatal error: 'sys/epoll.h' file not found
#include <sys/epoll.h>
         ^
1 error generated.
make: *** [src/main.o] Error 1
```

My compiler is

```
$ cc --version
Apple LLVM version 6.1.0 (clang-602.0.53) (based on LLVM 3.6.0svn)
Target: x86_64-apple-darwin14.5.0
Thread model: posix
```
